### PR TITLE
Add app's icon, track's cover and "Close" button to notification.

### DIFF
--- a/app/js/next-track-listener.js
+++ b/app/js/next-track-listener.js
@@ -1,4 +1,7 @@
 const NotificationCenter = require('node-notifier').NotificationCenter
+const path = require('path')
+
+const TRACK_COVER_SIZE = '50x50'
 
 const notifier = new NotificationCenter({
   withFallback: false,
@@ -11,19 +14,22 @@ document.addEventListener('DOMSubtreeModified', (event) => {
   if (event.target.className === 'player-controls__track-container' && trackTitle && externalAPI.isPlaying()) {
 
     const currentTrack = externalAPI.getCurrentTrack()
+    const currentTrackCover = `http://${currentTrack.cover.split('/').slice(0, -1).concat(TRACK_COVER_SIZE).join('/')}`
 
     notifier.notify(
       {
         title: 'Yandex.music',
-        subtitle: `${currentTrack.artists[0].title}`,
-        message: `${currentTrack.title}`,
-        contentImage: 'http://avatars.yandex.net/get-music-content/63210/94165464.a.2497608-1/50x50',
-        wait: false,
-        timeout: 5,
-        actions: 'next',
+        subtitle: currentTrack.artists[0].title,
+        message: currentTrack.title,
+        icon: path.join(__dirname, '../icons/mac/icon.icns'), // Absolute Path to Triggering Icon
+        contentImage: currentTrackCover, // Absolute Path to Attached Image (Content Image)
+        wait: false, // Wait for User Action against Notification or times out. Same as timeout = 5 seconds
+        timeout: 5, // Takes precedence over wait if both are defined.
+        closeLabel: 'Close', // String. Label for cancel button
+        actions: 'Next', // String | Array<String>. Action label or list of labels in case of dropdown,
       },
       (error, response, metadata) => {
-        if (metadata.activationValue === 'next') {
+        if (metadata.activationValue === 'Next') {
           externalAPI.next()
         }
       }


### PR DESCRIPTION
There's still an issue with this terminal icon.
I investigated the issue and found out that this problem appears because **node-notify** notifications for mac os are triggered by **terminal-notify**. I even tried to rebuild terminal-notify with this app's icon, but bumped into issues with notification actions disappearing.

As a result of this PR terminal icon is relocated to notification’s title lol.